### PR TITLE
remove unused import of ViewPropTypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types'
 import {
   Text,
   View,
-  ViewPropTypes,
   ScrollView,
   Dimensions,
   TouchableOpacity,


### PR DESCRIPTION
### Is it a bugfix ?
Yes
- If yes, which issue (fix #number) ?
- fixes #1228

### Is it a new feature ?
- No
### Describe what you've done:
Removed unused import
